### PR TITLE
Compatability with Cordova-sqlite-storage 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 [![npm](https://img.shields.io/npm/dm/localforage-cordovasqlitedriver.svg)](https://www.npmjs.com/package/localforage-cordovasqlitedriver)  
 SQLite driver for [Cordova](https://cordova.apache.org/) apps using [localForage](https://github.com/mozilla/localForage).
 
+## upgrade warning
+
+*BREAKING CHANGE*
+The default storage location for SQLite has changed in newer versions of [Cordova SQLite storage plugin](https://github.com/litehelpers/Cordova-sqlite-storage/)
+
+*WARNING*: The new "default" location value is NOT the same as the old default location and would break an upgrade for an app that was using the old default value (0) on iOS.
+
+If you are upgrading to a newer version of `localForage-cordovaSQLiteDriver` you need to verify where your previous storage location was and update the `location` property of the localForage database. Otherwise the default is `'default'`. This is to avoid breaking the iCloud Design Guide. See [here](https://github.com/litehelpers/Cordova-sqlite-storage#important-icloud-backup-of-sqlite-database-is-not-allowed) for further details.
+
 ## requirements
 
 * [Cordova](https://cordova.apache.org/)/[ionic](http://ionicframework.com/)

--- a/src/localforage-cordovasqlitedriver.js
+++ b/src/localforage-cordovasqlitedriver.js
@@ -6,7 +6,7 @@
  *
  * Copyright (c) 2015 Mozilla
  * Licensed under Apache 2.0 license.
- * 
+ *
  * ======================================
  *
  * base64-arraybuffer
@@ -113,8 +113,13 @@
                 // Open the database; the openDatabase API will automatically
                 // create it for us if it doesn't exist.
                 try {
-                    dbInfo.db = openDatabase(dbInfo.name, String(dbInfo.version),
-                                             dbInfo.description, dbInfo.size);
+                    dbInfo.db = openDatabase({
+                      name: dbInfo.name,
+                      version: String(dbInfo.version),
+                      description: dbInfo.description,
+                      size: dbInfo.size,
+                      location: 'default'
+                    });
                 } catch (e) {
                     reject(e);
                 }

--- a/src/localforage-cordovasqlitedriver.js
+++ b/src/localforage-cordovasqlitedriver.js
@@ -113,12 +113,13 @@
                 // Open the database; the openDatabase API will automatically
                 // create it for us if it doesn't exist.
                 try {
+                    dbInfo.location = dbInfo.location || 'default';
                     dbInfo.db = openDatabase({
-                      name: dbInfo.name,
-                      version: String(dbInfo.version),
-                      description: dbInfo.description,
-                      size: dbInfo.size,
-                      location: 'default'
+                        name: dbInfo.name,
+                        version: String(dbInfo.version),
+                        description: dbInfo.description,
+                        size: dbInfo.size,
+                        location: dbInfo.location
                     });
                 } catch (e) {
                     reject(e);


### PR DESCRIPTION
Note, this is a potentially breaking change and should be reviewed carefully.

Newer versions of the `Cordova-sqlite-storage` plugin require the first argument of `openDatabase()` be an object. This switches to the object form and specifies the `location` parameter to use the default `Library/LocalDatabase` path for storage to meet iCloud guidelines.

Users of the newer version of the driver and older version of the plugin may run into issues as they would be saving their storage to the older `default` location.
