### PR TITLE
Capture a rejected deviceReady correctly

### DIFF
--- a/dist/localforage-cordovasqlitedriver.es6.js
+++ b/dist/localforage-cordovasqlitedriver.es6.js
@@ -40,7 +40,7 @@ var deviceReady = new Promise(function (resolve, reject) {
     }
 });
 
-var openDatabasePromise = deviceReady.catch(Promise.resolve).then(function () {
+var openDatabasePromise = deviceReady.then(function () {
     return new Promise(function (resolve, reject) {
         if (typeof sqlitePlugin !== 'undefined' && typeof sqlitePlugin.openDatabase === 'function') {
             resolve(sqlitePlugin.openDatabase);
@@ -48,6 +48,8 @@ var openDatabasePromise = deviceReady.catch(Promise.resolve).then(function () {
             reject('SQLite plugin is not present.');
         }
     });
+}).catch(function () {
+    return Promise.resolve();
 });
 
 // // If cordova is not present, we can stop now.

--- a/dist/localforage-cordovasqlitedriver.js
+++ b/dist/localforage-cordovasqlitedriver.js
@@ -46,7 +46,7 @@
         }
     });
 
-    var openDatabasePromise = deviceReady.catch(Promise.resolve).then(function () {
+    var openDatabasePromise = deviceReady.then(function () {
         return new Promise(function (resolve, reject) {
             if (typeof sqlitePlugin !== 'undefined' && typeof sqlitePlugin.openDatabase === 'function') {
                 resolve(sqlitePlugin.openDatabase);
@@ -54,6 +54,8 @@
                 reject('SQLite plugin is not present.');
             }
         });
+    }).catch(function () {
+        return Promise.resolve();
     });
 
     // // If cordova is not present, we can stop now.

--- a/lib/cordova-sqlite.js
+++ b/lib/cordova-sqlite.js
@@ -13,7 +13,7 @@ var deviceReady = new Promise(function(resolve, reject) {
     }
 });
 
-export var openDatabasePromise = deviceReady.catch(Promise.resolve).then(function() {
+export var openDatabasePromise = deviceReady.then(function() {
     return new Promise(function(resolve, reject) {
         if (typeof sqlitePlugin !== 'undefined' &&
             typeof sqlitePlugin.openDatabase === 'function') {
@@ -22,4 +22,6 @@ export var openDatabasePromise = deviceReady.catch(Promise.resolve).then(functio
             reject('SQLite plugin is not present.');
         }
     });
+}).catch(function() {
+  return Promise.resolve();
 });


### PR DESCRIPTION
Do not throw errors in the console when running on desktop (where cordova is undefined).
It's likely the solution (and the description) for
https://github.com/thgreasi/localForage-cordovaSQLiteDriver/issues/2
